### PR TITLE
Fix trimmer trying to load a file with wrong extension

### DIFF
--- a/QuickRecorder/SCContext.swift
+++ b/QuickRecorder/SCContext.swift
@@ -319,8 +319,7 @@ class SCContext {
                                 showNotification(title: "Recording Completed".local, body: String(format: "File saved to: %@".local, url.path), id: "quickrecorder.completed.\(Date.now)")
                                 if ud.bool(forKey: "trimAfterRecord") {
                                     DispatchQueue.main.async {
-                                        let fileURL = URL(fileURLWithPath: filePath).deletingPathExtension()
-                                        AppDelegate.shared.createNewWindow(view: VideoTrimmerView(videoURL: fileURL), title: fileURL.lastPathComponent)
+                                        AppDelegate.shared.createNewWindow(view: VideoTrimmerView(videoURL: url), title: url.lastPathComponent)
                                     }
                                 }
                             case .failure(let error):


### PR DESCRIPTION
It tried to load video.mp4.mp4 instead of video.mp4

![Screenshot 2024-05-20 at 15 02 38](https://github.com/lihaoyun6/QuickRecorder/assets/82064173/616f44b3-d2f0-48d4-9678-5f9ba5812f54)

This app is really cool and I'll be probably making a few PRs. Rip to the app I was making :P