### PR TITLE
Fix mic.m4a corruption in system audio mode

### DIFF
--- a/QuickRecorder/SCContext.swift
+++ b/QuickRecorder/SCContext.swift
@@ -385,7 +385,17 @@ class SCContext {
             }
             dispatchGroup.wait()
         } else {
-            if ud.bool(forKey: "recordMic") { vW.finishWriting {} }
+            if ud.bool(forKey: "recordMic") {
+                let dispatchGroup = DispatchGroup()
+                dispatchGroup.enter()
+                vW.finishWriting {
+                    if vW.status != .completed {
+                        print("Mic writing failed with status: \(vW.status), error: \(String(describing: vW.error))")
+                    }
+                    dispatchGroup.leave()
+                }
+                dispatchGroup.wait()
+            }
         }
         
         DispatchQueue.main.async {


### PR DESCRIPTION
## Summary

- In system audio recording mode, `vW.finishWriting {}` was called with an empty completion handler and no synchronization, causing a race condition where the `.qma` package processing (audio remixing, format conversion) could start before `AVAssetWriter` had written the `moov` atom to `mic.m4a`
- Since `moov` is written last in M4A files, this produced corrupt `mic.m4a` files that are unreadable by any audio tool (`moov atom not found`)
- The video recording path already correctly uses `DispatchGroup` to block until `finishWriting` completes — this PR applies the same pattern to the system audio path

## Details

The bug is on line 388 of `SCContext.swift`:
```swift
// Before (fire-and-forget, no synchronization):
if ud.bool(forKey: "recordMic") { vW.finishWriting {} }

// After (synchronized, matching the video path pattern):
if ud.bool(forKey: "recordMic") {
    let dispatchGroup = DispatchGroup()
    dispatchGroup.enter()
    vW.finishWriting {
        if vW.status != .completed {
            print("Mic writing failed with status: \(vW.status), error: \(String(describing: vW.error))")
        }
        dispatchGroup.leave()
    }
    dispatchGroup.wait()
}
```

Without the wait, subsequent code at lines 423-434 loads and remixes the `.qma` package immediately, before the mic file is finalized. The race is also exacerbated by cloud storage services syncing the incomplete file before the `moov` atom is flushed.

## Test plan

- [ ] Record system audio with mic enabled, verify `mic.m4a` has a valid `moov` atom after recording stops
- [ ] Verify `.qma` package remixing works correctly (audio from both tracks is present)
- [ ] Verify no UI freeze during the `finishWriting` wait (should be near-instant for audio-only writes)