### PR TITLE
Add ScreenCaptureKit microphone capture on macOS 15+Feature/screencapturekit microphone

### DIFF
--- a/QuickRecorder/QuickRecorderApp.swift
+++ b/QuickRecorder/QuickRecorderApp.swift
@@ -19,6 +19,12 @@ import Sparkle
 let isMacOS12 = ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 12
 let isMacOS14 = ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 14
 let isMacOS15 = ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 15
+let supportsScreenCaptureKitMicrophone: Bool = {
+#if compiler(>=6.0)
+    if #available(macOS 15.0, *) { return true }
+#endif
+    return false
+}()
 var scPerm = false
 let fd = FileManager.default
 let ud = UserDefaults.standard
@@ -113,12 +119,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SCStreamDelegate, SCStreamOu
     var isResizing = false
     var presenterType = "OFF"
     var frameQueue = FixedLengthArray<CMTime>(maxLength: 20)
+    let screenCaptureKitMicrophoneQueue = DispatchQueue(label: "com.lihaoyun6.QuickRecorder.screencapturekit.microphone")
     
     @AppStorage("showOnDock")       var showOnDock: Bool = true
     @AppStorage("showMenubar")      var showMenubar: Bool = false
     @AppStorage("enableAEC")        var enableAEC: Bool = false
     @AppStorage("recordMic")        var recordMic: Bool = false
     @AppStorage("micDevice")        var micDevice: String = "default"
+    @AppStorage("useScreenCaptureKitMicrophone") var useScreenCaptureKitMicrophone: Bool = supportsScreenCaptureKitMicrophone
     @AppStorage("remuxAudio")       var remuxAudio: Bool = true
     @AppStorage("recordWinSound")   var recordWinSound: Bool = true
     @AppStorage("recordHDR")        var recordHDR: Bool = false
@@ -231,6 +239,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SCStreamDelegate, SCStreamOu
                 "saveDirectory": userDesktop as NSString,
                 "showMouse": true,
                 "recordMic": false,
+                "useScreenCaptureKitMicrophone": supportsScreenCaptureKitMicrophone,
                 "remuxAudio": isMacOS12 ? false : true,
                 "recordWinSound": isMacOS12 ? false : true,
                 "trimAfterRecord": false,
@@ -245,6 +254,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SCStreamDelegate, SCStreamOu
         )
         
         if highRes == 0 { highRes = 2 }
+        if !supportsScreenCaptureKitMicrophone { useScreenCaptureKitMicrophone = false }
         if showOnDock { NSApp.setActivationPolicy(.regular) }
         if isMacOS12 { showPreview = false; remuxAudio = false }
         

--- a/QuickRecorder/RecordEngine.swift
+++ b/QuickRecorder/RecordEngine.swift
@@ -218,6 +218,20 @@ extension AppDelegate {
             conf.sampleRate = 48000
             conf.channelCount = 2
         }
+
+        SCContext.usesScreenCaptureKitMicrophone = false
+#if compiler(>=6.0)
+        if #available(macOS 15.0, *), recordMic && useScreenCaptureKitMicrophone {
+            SCContext.usesScreenCaptureKitMicrophone = true
+            conf.captureMicrophone = true
+            if micDevice != "default", let microphone = SCContext.getCurrentMic() {
+                conf.microphoneCaptureDeviceID = microphone.uniqueID
+            }
+        }
+#endif
+        if recordMic {
+            print("Microphone capture method: \(SCContext.usesScreenCaptureKitMicrophone ? "ScreenCaptureKit" : "Legacy")")
+        }
         
 
         //  conf.minimumFrameInterval = CMTime(value: 1, timescale: audioOnly ? CMTimeScale.max : CMTimeScale(frameRate))
@@ -286,14 +300,20 @@ extension AppDelegate {
         do {
             try SCContext.stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: .global())
             if #available(macOS 13, *) { try SCContext.stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global()) }
+#if compiler(>=6.0)
+            if #available(macOS 15.0, *), SCContext.usesScreenCaptureKitMicrophone {
+                try SCContext.stream.addStreamOutput(self, type: .microphone, sampleHandlerQueue: screenCaptureKitMicrophoneQueue)
+            }
+#endif
             if !audioOnly {
                 initVideo(conf: conf)
             } else {
                 //SCContext.startTime = Date.now
-                if recordMic { startMicRecording() }
+                if recordMic && !SCContext.usesScreenCaptureKitMicrophone { startMicRecording() }
             }
             try await SCContext.stream.startCapture()
         } catch {
+            SCContext.usesScreenCaptureKitMicrophone = false
             assertionFailure("capture failed".local)
             return
         }
@@ -430,7 +450,7 @@ extension AppDelegate {
             SCContext.micInput = AVAssetWriterInput(mediaType: AVMediaType.audio, outputSettings: settings)
             SCContext.micInput.expectsMediaDataInRealTime = true
             if SCContext.vW.canAdd(SCContext.micInput) { SCContext.vW.add(SCContext.micInput) }
-            startMicRecording()
+            if !SCContext.usesScreenCaptureKitMicrophone { startMicRecording() }
         }
         SCContext.vW.startWriting()
     }
@@ -614,7 +634,13 @@ extension AppDelegate {
             }
 #if compiler(>=6.0)
         case .microphone:
-            break
+            guard SCContext.usesScreenCaptureKitMicrophone, SCContext.startTime != nil else { return }
+            if SCContext.timeOffset.value > 0 {
+                SampleBuffer = SCContext.adjustTime(sample: SampleBuffer, by: SCContext.timeOffset) ?? sampleBuffer
+            }
+            if SCContext.micInput.isReadyForMoreMediaData {
+                SCContext.micInput.append(SampleBuffer)
+            }
 #endif
         @unknown default:
             assertionFailure("unknown stream type".local)

--- a/QuickRecorder/SCContext.swift
+++ b/QuickRecorder/SCContext.swift
@@ -45,6 +45,7 @@ class SCContext {
     static var startTime: Date?
     static var timePassed: TimeInterval = 0
     static var stream: SCStream!
+    static var usesScreenCaptureKitMicrophone = false
     static var screen: SCDisplay?
     static var window: [SCWindow]?
     static var application: [SCRunningApplication]?
@@ -343,11 +344,13 @@ class SCContext {
         stream = nil
         if ud.bool(forKey: "recordMic") {
             micInput.markAsFinished()
-            AudioRecorder.shared.stop()
-            audioEngine.inputNode.removeTap(onBus: 0)
-            audioEngine.stop()
-            //DispatchQueue.global().async { try? audioEngine.inputNode.setVoiceProcessingEnabled(false) }
-            if ud.bool(forKey: "enableAEC") { try? AECEngine.stopAudioUnit() }
+            if !usesScreenCaptureKitMicrophone {
+                AudioRecorder.shared.stop()
+                audioEngine.inputNode.removeTap(onBus: 0)
+                audioEngine.stop()
+                //DispatchQueue.global().async { try? audioEngine.inputNode.setVoiceProcessingEnabled(false) }
+                if ud.bool(forKey: "enableAEC") { try? AECEngine.stopAudioUnit() }
+            }
         }
         if streamType != .systemaudio {
             let dispatchGroup = DispatchGroup()
@@ -473,6 +476,7 @@ class SCContext {
         }
         
         streamType = nil
+        usesScreenCaptureKitMicrophone = false
         firstFrame = nil
     }
     

--- a/QuickRecorder/ViewModel/SettingsView.swift
+++ b/QuickRecorder/ViewModel/SettingsView.swift
@@ -29,13 +29,13 @@ struct SettingsView: View {
                 NavigationLink(destination: HotkeyView(), tag: "Hotkey", selection: $selectedItem) {
                     Label("Hotkey", image: "hotkey")
                 }
-                NavigationLink(destination: BlocklistView(), tag: "Blaoklist", selection: $selectedItem) {
+                NavigationLink(destination: BlocklistView(), tag: "Blocklist", selection: $selectedItem) {
                     Label("Blocklist", image: "blacklist")
                 }
             }
             .listStyle(.sidebar)
             .padding(.top, 9)
-        }.frame(width: 600, height: 512)
+        }.frame(width: 600, height: 560)
     }
 }
 
@@ -118,7 +118,7 @@ struct RecorderView: View {
                 SToggle(
                     "Use ScreenCaptureKit for Microphone Recording",
                     isOn: $useScreenCaptureKitMicrophone,
-                    tips: "Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path."
+                    tips: "Use the modern microphone capture path on macOS 15 or later. Enabling this is recommended."
                 )
                 .disabled(!supportsScreenCaptureKitMicrophone)
                 SDivider()

--- a/QuickRecorder/ViewModel/SettingsView.swift
+++ b/QuickRecorder/ViewModel/SettingsView.swift
@@ -106,6 +106,7 @@ struct RecorderView: View {
     @AppStorage("preventSleep")     private var preventSleep: Bool = true
     @AppStorage("showPreview")      private var showPreview: Bool = true
     @AppStorage("hideCCenter")      private var hideCCenter: Bool = false
+    @AppStorage("useScreenCaptureKitMicrophone") private var useScreenCaptureKitMicrophone: Bool = supportsScreenCaptureKitMicrophone
     
     @State private var userColor: Color = Color.black
 
@@ -113,6 +114,13 @@ struct RecorderView: View {
         SForm(spacing: 10) {
             SGroupBox(label: "Recorder") {
                 SSteper("Delay Before Recording", value: $countdown, min: 0, max: 99)
+                SDivider()
+                SToggle(
+                    "Use ScreenCaptureKit for Microphone Recording",
+                    isOn: $useScreenCaptureKitMicrophone,
+                    tips: "Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path."
+                )
+                .disabled(!supportsScreenCaptureKitMicrophone)
                 SDivider()
                 if #available(macOS 14, *) {
                     SSteper("Presenter Overlay Delay", value: $poSafeDelay, min: 0, max: 99, tips: "If enabling Presenter Overlay causes recording failure, please increase this value.")

--- a/QuickRecorder/zh-Hans.lproj/Localizable.strings
+++ b/QuickRecorder/zh-Hans.lproj/Localizable.strings
@@ -214,7 +214,7 @@
 "QuickRecorder needs this permission to record your camera or mobile device." = "QuickRecorder 需要使用此权限以录制来自摄像头或移动设备的画面.";
 "Select Window Directly" = "直接点选窗口";
 "Use ScreenCaptureKit for Microphone Recording" = "使用 ScreenCaptureKit 录制麦克风";
-"Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path." = "在 macOS 15 或更高版本上使用新的麦克风录制方式。关闭后将使用旧版 AVAudioEngine 录制方式。";
+"Use the modern microphone capture path on macOS 15 or later. Enabling this is recommended." = "在 macOS 15 或更高版本上使用新的麦克风录制方式。建议开启。";
 
 // Please don't translate the following warning strings, it will make it difficult for me to read the logs
 "failed to fetch file for size indicator: %@" = "获取文件大小失败: ";

--- a/QuickRecorder/zh-Hans.lproj/Localizable.strings
+++ b/QuickRecorder/zh-Hans.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Would you like to use H.265 format for better video quality and smaller file size?" = "是否使用 H.265 编码格式以获得\n更好的录像画质和更小的文件体积?";
 "QuickRecorder needs this permission to record your camera or mobile device." = "QuickRecorder 需要使用此权限以录制来自摄像头或移动设备的画面.";
 "Select Window Directly" = "直接点选窗口";
+"Use ScreenCaptureKit for Microphone Recording" = "使用 ScreenCaptureKit 录制麦克风";
+"Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path." = "在 macOS 15 或更高版本上使用新的麦克风录制方式。关闭后将使用旧版 AVAudioEngine 录制方式。";
 
 // Please don't translate the following warning strings, it will make it difficult for me to read the logs
 "failed to fetch file for size indicator: %@" = "获取文件大小失败: ";

--- a/QuickRecorder/zh-Hant.lproj/Localizable.strings
+++ b/QuickRecorder/zh-Hant.lproj/Localizable.strings
@@ -211,6 +211,8 @@
 "Would you like to use H.265 format for better video quality and smaller file size?" = "是否使用 H.265 編碼以獲得更好的錄影畫質和更小的檔案體積?";
 "QuickRecorder needs this permission to record your camera or mobile device." = "QuickRecorder 需要此權限以錄製來自攝像頭或行動裝置的畫面.";
 "Select Window Directly" = "直接點選視窗";
+"Use ScreenCaptureKit for Microphone Recording" = "使用 ScreenCaptureKit 錄製麥克風";
+"Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path." = "在 macOS 15 或更高版本上使用新的麥克風錄製方式。關閉後將使用舊版 AVAudioEngine 錄製方式。";
 
 // Please don't translate the following warning strings, it will make it difficult for me to read the logs
 "failed to fetch file for size indicator: %@" = "获取文件大小失败: ";

--- a/QuickRecorder/zh-Hant.lproj/Localizable.strings
+++ b/QuickRecorder/zh-Hant.lproj/Localizable.strings
@@ -212,7 +212,7 @@
 "QuickRecorder needs this permission to record your camera or mobile device." = "QuickRecorder 需要此權限以錄製來自攝像頭或行動裝置的畫面.";
 "Select Window Directly" = "直接點選視窗";
 "Use ScreenCaptureKit for Microphone Recording" = "使用 ScreenCaptureKit 錄製麥克風";
-"Use the modern microphone capture path on macOS 15 or later. Turn this off to use the legacy AVAudioEngine path." = "在 macOS 15 或更高版本上使用新的麥克風錄製方式。關閉後將使用舊版 AVAudioEngine 錄製方式。";
+"Use the modern microphone capture path on macOS 15 or later. Enabling this is recommended." = "在 macOS 15 或更高版本上使用新的麥克風錄製方式。建議開啟。";
 
 // Please don't translate the following warning strings, it will make it difficult for me to read the logs
 "failed to fetch file for size indicator: %@" = "获取文件大小失败: ";


### PR DESCRIPTION
## Summary

- Capture microphone audio through `SCStream` on macOS 15+ using
  `captureMicrophone` and the `.microphone` stream output.
- Retain the existing microphone capture implementation as the legacy fallback.
- Add a Recording Settings toggle that lets users switch between the new
  and legacy microphone capture methods.
- Enable the new method by default on macOS 15+, while keeping it disabled
  on older systems.
- Apply the new microphone capture path to both audio-only and video recordings.
- Update the settings window layout and add localized descriptions for the
  new recording setting.

## Motivation

This failure primarily affects the `Default` microphone selection. Explicitly
selected microphones are already pinned to a specific capture device and
therefore do not normally follow default-input route changes.

When recording with the microphone input set to `Default`, macOS may change
the default input route or audio format after recording has already started.
This can happen when AirPods become active during a recording.

With the legacy `AVAudioEngine` input tap, this route or format change may
cause the microphone tap to stop delivering valid buffers. In the tested
scenario, starting with the Mac's built-in microphone and then putting on
AirPods caused the microphone track to disappear while system audio continued.

On macOS 15+, this change captures the microphone through the recording's
existing `SCStream`. In the same scenario, microphone capture continued from
the input device used when recording started, so the microphone track remained
available throughout the recording.

This also places microphone samples on the same capture timeline as the other
ScreenCaptureKit outputs.

## Behavior

When the microphone input is set to `Default`, testing showed that the
ScreenCaptureKit path continued using the input device selected when capture
started.

- If recording starts with the Mac's built-in microphone and AirPods become
  active later, recording continues from the original built-in microphone.
- The microphone does not automatically switch to AirPods during the recording.
- If recording starts with AirPods, AirPods remain the microphone source after
  they are removed from the user's ears, as long as they remain connected.
- If the AirPods are placed in their case and disconnect, the current
  implementation stops receiving microphone samples.

In the tested route-change scenario, unlike the legacy path, microphone capture
was not lost while the original input device remained available.

## Compatibility

- macOS 15+: the ScreenCaptureKit microphone path is available and enabled
  by default.
- macOS 12.3–14: the existing microphone implementation remains in use, and
  the new setting is disabled.
- On supported systems, users can manually switch back to the legacy
  implementation in Recording Settings.

## Testing

- Debug build succeeded.
- Release build succeeded.
- Tested audio-only recording with both system audio and microphone audio.
- Tested starting with the Mac's built-in microphone and putting on AirPods
  during recording:
  - Legacy path: microphone recording stopped after the input route changed.
  - ScreenCaptureKit path: microphone recording continued from the original
    built-in microphone.
- Tested starting with AirPods, removing them, and placing them in their case:
  - Microphone recording continued while AirPods remained connected.
  - Microphone samples stopped after AirPods disconnected.
- Tested video recording with system audio and microphone.
- Tested recording with the legacy microphone capture setting.

## Known Limitation

The current implementation does not reconfigure the active `SCStream` when
the input device selected at the start of recording becomes unavailable.

For example, if recording starts with AirPods and they are later placed in
their case, microphone samples stop after the AirPods disconnect. Automatically
rebinding the stream to the new default input device is outside the scope of
this change and can be addressed separately.