### PR TITLE
Fix excessive output frame rates when 60 FPS or higher is selected

### DIFF
--- a/QuickRecorder/RecordEngine.swift
+++ b/QuickRecorder/RecordEngine.swift
@@ -220,8 +220,7 @@ extension AppDelegate {
         }
         
 
-        //  conf.minimumFrameInterval = CMTime(value: 1, timescale: audioOnly ? CMTimeScale.max : CMTimeScale(frameRate))
-         conf.minimumFrameInterval = CMTime(value: 1, timescale: audioOnly ? CMTimeScale.max : (frameRate >= 60 ? 0 : CMTimeScale(frameRate)))
+        conf.minimumFrameInterval = CMTime(value: 1, timescale: audioOnly ? CMTimeScale.max : CMTimeScale(frameRate))
 
 //        CMTimeScale is the denominator in the fraction
 //        conf.minimumFrameInterval = CMTime(seconds: audioOnly ? Double(CMTimeScale.max) : Double(1)/Double(frameRate), preferredTimescale: 10000)


### PR DESCRIPTION
## Summary

This PR ensures that ScreenCaptureKit respects the user-selected maximum frame rate when 60 FPS or higher is selected.

Currently, QuickRecorder disables frame throttling for frame-rate settings greater than or equal to 60 FPS:

```swift
conf.minimumFrameInterval = CMTime(
    value: 1,
    timescale: audioOnly
        ? CMTimeScale.max
        : (frameRate >= 60 ? 0 : CMTimeScale(frameRate))
)
```

On high-refresh-rate displays, this allows ScreenCaptureKit to deliver frames at the maximum supported display rate instead of the frame rate selected in QuickRecorder.

For example, two recordings configured for 60 FPS produced the following results:

| Configured FPS | Recorded duration | Video samples | Reported average FPS |
| --- | ---: | ---: | ---: |
| 60 FPS | 56.32 seconds | 5,801 | 102.91 FPS |
| 60 FPS | 681.38 seconds | 73,315 | 107.57 FPS |

This can create unnecessarily demanding video streams and may cause playback to fall behind or appear slowed down on QuickTime Player and other devices.

## Change

Always use the configured frame rate as `minimumFrameInterval`:

```swift
conf.minimumFrameInterval = CMTime(
    value: 1,
    timescale: audioOnly
        ? CMTimeScale.max
        : CMTimeScale(frameRate)
)
```

## Expected behavior

- Selecting 30 FPS limits ScreenCaptureKit delivery to at most 30 FPS.
- Selecting 60 FPS limits delivery to at most 60 FPS.
- Selecting 120 FPS limits delivery to at most 120 FPS.
- ScreenCaptureKit may still emit fewer frames when the screen content is static.
- Recordings remain variable-frame-rate; this change does not insert duplicate frames or perform frame resampling.
- Audio-only recording behavior is unchanged.

`AVVideoExpectedSourceFrameRateKey` remains useful as an encoder hint, but it does not enforce a maximum input frame rate by itself.

## Testing

The issue was reproduced with two QuickRecorder 1.6.9 HEVC recordings configured for 60 FPS on a high-refresh-rate display. Both outputs exceeded 100 FPS.

The generated files were inspected using AVFoundation, including their duration, video sample count, presentation timestamps, nominal frame rate, and audio/video track duration.

The change is intentionally limited to the ScreenCaptureKit frame-delivery interval. No encoding, timestamp-adjustment, or VFR behavior is otherwise changed.

A full Xcode build was not performed because Xcode is not available in the current test environment.